### PR TITLE
Allowed encoding of remaining length with 4 bytes according to spec

### DIFF
--- a/repository/MQTT-Core/MQTTPacket.class.st
+++ b/repository/MQTT-Core/MQTTPacket.class.st
@@ -18,7 +18,7 @@ MIT License.
 Class {
 	#name : #MQTTPacket,
 	#superclass : #Object,
-	#category : 'MQTT-Core'
+	#category : #'MQTT-Core'
 }
 
 { #category : #accessing }
@@ -156,7 +156,7 @@ MQTTPacket >> readRemainingLengthFrom: binaryStream [
 		byte := binaryStream next.
 		length := length + ((byte bitAnd: 127) * multiplier).
 		multiplier := multiplier * 128.
-		self assert: multiplier < (128 ** 3).
+		self assert: multiplier <= (128 ** 3).
 		(byte bitAt: 8) = 1 ] whileTrue.
 	^ length
 ]


### PR DESCRIPTION
see http://docs.oasis-open.org/mqtt/mqtt/v3.1.1/os/mqtt-v3.1.1-os.html#_Toc398718023